### PR TITLE
Add option to sync every 30 minutes

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -88,6 +88,7 @@
   <string-array name="settings_sync_interval_names">
     <item>Pouze manuálně</item>
     <item>Každých 15 minut</item>
+    <item>Každých 30 minut</item>
     <item>Každou hodinu</item>
     <item>Každé 2 hodiny</item>
     <item>Každé 4 hodiny</item>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -75,6 +75,7 @@
   <string-array name="settings_sync_interval_names">
     <item>Kun manuelt</item>
     <item>Hver 15. minut</item>
+    <item>Hver 30. minut</item>
     <item>En gang i timen</item>
     <item>En gang hver 2. time</item>
     <item>En gang hver 4. time</item>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -122,6 +122,7 @@
     <string-array name="settings_sync_interval_names">
         <item>Nur manuell</item>
         <item>Alle 15 Minuten</item>
+        <item>Alle 30 Minuten</item>
         <item>Jede Stunde</item>
         <item>Alle 2 Stunde</item>
         <item>Alle 4 Stunde</item>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -88,6 +88,7 @@
   <string-array name="settings_sync_interval_names">
     <item>Solo manualmente</item>
     <item>Cada 15 minutos</item>
+    <item>Cada 30 minutos</item>
     <item>Cada hora</item>
     <item>Cada 2 horas</item>
     <item>Cada 4 horas</item>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -88,6 +88,7 @@
     <string-array name="settings_sync_interval_names">
         <item>Manuellement</item>
         <item>Toutes les 15 minutes</item>
+        <item>Toutes les 30 minutes</item>
         <item>Toutes les heures</item>
         <item>Toutes les 2 heures</item>
         <item>Toutes les 4 heures</item>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -88,6 +88,7 @@
   <string-array name="settings_sync_interval_names">
     <item>Manuális</item>
     <item>15 percenként</item>
+    <item>30 percenként</item>
     <item>Óránként</item>
     <item>2 óránként</item>
     <item>4 óránként</item>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -86,6 +86,7 @@
     <string-array name="settings_sync_interval_names">
         <item>Solo manualmente</item>
         <item>Ogni 15 minuti</item>
+        <item>Ogni 30 minuti</item>
         <item>Ogni ora</item>
         <item>Ogni 2 ore</item>
         <item>Ogni 4 ore</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -88,6 +88,7 @@
   <string-array name="settings_sync_interval_names">
     <item>手動のみ</item>
     <item>15 分ごと</item>
+    <item>30 分ごと</item>
     <item>1 時間ごと</item>
     <item>2 時間ごと</item>
     <item>4 時間ごと</item>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -240,6 +240,7 @@
     <string-array name="settings_sync_interval_names">
         <item>Bare manuelt</item>
         <item>Hvert 15. minutt</item>
+        <item>Hvert 30. minutt</item>
         <item>Hver time</item>
         <item>Annenhver time</item>
         <item>Hver 4. time</item>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -82,6 +82,7 @@
     <string-array name="settings_sync_interval_names">
         <item>Alleen handmatig</item>
         <item>Elke 15 minuten</item>
+        <item>Elke 30 minuten</item>
         <item>Elk uur</item>
         <item>Elke 2 uur</item>
         <item>Elke 4 uur</item>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -216,6 +216,7 @@
     <string-array name="settings_sync_interval_names">
         <item>Tylko ręcznie</item>
         <item>Co 15 minut</item>
+        <item>Co 30 minut</item>
         <item>Co godzinę</item>
         <item>Co 2 godziny</item>
         <item>Co 4 godziny</item>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -88,6 +88,7 @@
   <string-array name="settings_sync_interval_names">
     <item>Apenas manualmente</item>
     <item>A cada 15 minutos</item>
+    <item>A cada 30 minutos</item>
     <item>A cada hora</item>
     <item>A cada 2 horas</item>
     <item>A cada 4 horas</item>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -24,6 +24,7 @@
   <string-array name="settings_sync_interval_names">
     <item>Apenas manualmente</item>
     <item>A cada 15 minutos</item>
+    <item>A cada 30 minutos</item>
     <item>A cada hora</item>
     <item>A cada 2 horas</item>
     <item>A cada 4 horas</item>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -25,6 +25,7 @@
     <string-array name="settings_sync_interval_names">
         <item>Вручную</item>
         <item>Каждые 15 минут</item>
+        <item>Каждые 30 минут</item>
         <item>Каждый час</item>
         <item>Каждые 2 часа</item>
         <item>Каждые 4 часа</item>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -88,6 +88,7 @@
   <string-array name="settings_sync_interval_names">
     <item>Само ручно</item>
     <item>Сваких 15 минута</item>
+    <item>Сваких 30 минута</item>
     <item>Сваког сата</item>
     <item>Свака 2 сата</item>
     <item>Свака 4 сата</item>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -75,6 +75,7 @@
     <string-array name="settings_sync_interval_names">
         <item>Sadece elle</item>
         <item>Her 15 dakikada bir</item>
+        <item>Her 30 dakikada bir</item>
         <item>Her saatte bir</item>
         <item>Her 2 saatte bir</item>
         <item>Her 4 saatte bir</item>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -24,6 +24,7 @@
   <string-array name="settings_sync_interval_names">
     <item>Лише вручну</item>
     <item>Кожних 15 хвилин</item>
+    <item>Кожних 30 хвилин</item>
     <item>Щогодини</item>
     <item>Кожних 2 години</item>
     <item>Кожних 4 години</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,8 +315,8 @@
     <string name="settings_sync_summary_not_available">Not available</string>
     <string-array name="settings_sync_interval_seconds" translateable="false">
         <item>-1</item>
-        <item>300</item>
         <item>900</item>
+        <item>1800</item>
         <item>3600</item>
         <item>7200</item>
         <item>14400</item>
@@ -324,8 +324,8 @@
     </string-array>
     <string-array name="settings_sync_interval_names">
         <item>Only manually</item>
-        <item>Every 5 minutes</item>
         <item>Every 15 minutes</item>
+        <item>Every 30 minutes</item>
         <item>Every hour</item>
         <item>Every 2 hours</item>
         <item>Every 4 hours</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,6 +315,7 @@
     <string name="settings_sync_summary_not_available">Not available</string>
     <string-array name="settings_sync_interval_seconds" translateable="false">
         <item>-1</item>
+        <item>300</item>
         <item>900</item>
         <item>3600</item>
         <item>7200</item>
@@ -323,6 +324,7 @@
     </string-array>
     <string-array name="settings_sync_interval_names">
         <item>Only manually</item>
+        <item>Every 5 minutes</item>
         <item>Every 15 minutes</item>
         <item>Every hour</item>
         <item>Every 2 hours</item>


### PR DESCRIPTION
I wanted more granularity between the current existing sync intervals of "Every 15 minutes" and "Every hour". I thought others may want this interval as well.

Here's a few screenshots showing the interval is properly set and retrieved from [`android.content.ContentResolver`](https://developer.android.com/reference/kotlin/android/content/ContentResolver#addPeriodicSync(android.accounts.Account,%20kotlin.String,%20android.os.Bundle,%20kotlin.Long)) (note: `period` and `seconds` are both set to `1800` seconds when `Every 30 minutes` is selected:
![](https://user-images.githubusercontent.com/14011954/124221205-4a9ebd00-dacd-11eb-8e08-0858fc1f0a5a.png)

![](https://user-images.githubusercontent.com/14011954/124221208-4b375380-dacd-11eb-9ab7-f3662b240fd5.png)

I didn't update the [`strings.xml` files](https://github.com/etesync/android/tree/master/app/src/main/res) for other languages because I didn't want to mess up the translation. 