### PR TITLE
Explicitly added package names for tasks.org and opentasks

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,7 +117,7 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.0.9'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
 
     implementation "org.jetbrains.anko:anko-commons:0.10.4"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,10 @@
           xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           android:installLocation="internalOnly">
+    <queries>
+        <package android:name="org.dmfs.tasks" />
+        <package android:name="org.tasks" />
+    </queries>
 
     <!-- normal permissions -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>


### PR DESCRIPTION
Fixes #226 

Since SDK 30 Android filters the list of installed packages. To still be able to detect tasks.org and opentasks their packagenames have been added to the AndroidManifest.xml as described here: https://developer.android.com/training/package-visibility/declaring#package-name

I also had to up "desugar_jdk_libs" to 1.1.5 to prevent an error (`Missing class java.lang.Math8 (referenced from: j$.time.Duration j$.time.Duration.create(boolean, long, long, long, long, int) and 42 other contexts)`). (https://stackoverflow.com/questions/71332083/didnt-find-class-java-lang-math8-on-path-dexpathlist)
