### PR TITLE
Add `POST_NOTIFICATIONS` permission to app's manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="android.permission.READ_SYNC_STATS"/>
     <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS"/>
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <!-- account management permissions not required for own accounts since API level 22 -->
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" android:maxSdkVersion="22"/>


### PR DESCRIPTION
Since we updated the target SDK version to 33 in [3f05b7fc1fcc7fea06d5dd2d863188a784ad27e9](https://github.com/etesync/android/commit/3f05b7fc1fcc7fea06d5dd2d863188a784ad27e9), we should request [notifications permissions](https://developer.android.com/develop/ui/views/notifications/notification-permission) to continue allowing the user to receive journal changes and certificate notifications. In some cases, the lack of notifications may block Android 13 users from accepting certificates, which will prevent them from syncing with the Etebase server

Current state of EteSync on a device running Android 13:
![image](https://github.com/etesync/android/assets/14011954/441fbad3-f2bb-481e-a5df-f7d88a77f313)


