### PR TITLE
Update libraries to successfully build again

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,11 +144,11 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.0-beta01'
     implementation "androidx.legacy:legacy-preference-v14:$supportVersion"
     implementation 'com.github.yukuku:ambilwarna:2.0.1'
-    implementation ('com.github.worker8:tourguide:1.0.17-SNAPSHOT@aar') {
+    implementation ('com.github.worker8:tourguide:1.0.18-SNAPSHOT@aar') {
         transitive = true
     }
 
-    def requeryVersion = '1.6.1'
+    def requeryVersion = '1.6.0'
     implementation "io.requery:requery:$requeryVersion"
     implementation "io.requery:requery-android:$requeryVersion"
     implementation "io.requery:requery-kotlin:$requeryVersion"
@@ -163,7 +163,7 @@ dependencies {
     implementation 'org.apache.commons:commons-collections4:4.1'
     implementation 'org.apache.commons:commons-lang3:3.8.1'
 
-    implementation 'net.cachapa.expandablelayout:expandablelayout:2.9.2'
+    implementation 'com.github.cachapa:ExpandableLayout:2.9.2'
     implementation project(':cert4android')
     implementation project(':ical4android')
     implementation project(':vcard4android')

--- a/app/src/main/java/com/etesync/syncadapter/utils/ShowcaseBuilder.kt
+++ b/app/src/main/java/com/etesync/syncadapter/utils/ShowcaseBuilder.kt
@@ -7,7 +7,7 @@ import tourguide.tourguide.TourGuide
 
 object ShowcaseBuilder {
     fun getBuilder(activity: Activity): TourGuide {
-        val ret = TourGuide.init(activity).with(TourGuide.Technique.Click)
+        val ret = TourGuide.init(activity).with(TourGuide.Technique.CLICK)
                 .setPointer(Pointer())
         ret.setOverlay(Overlay().setOnClickListener { ret.cleanUp() })
 

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ allprojects {
         maven() {
             url 'https://oss.sonatype.org/content/repositories/snapshots'
         }
+        maven { url 'https://jitpack.io' }
+        maven { url 'https://artifactory.appodeal.com/appodeal-public' }
         google()
     }
 }


### PR DESCRIPTION
1. Update the following libraries in `app/build.gradle` to successfully build again:
    - com.github.worker8:tourguide upgraded to 1.0.18-SNAPSHOT
    - requeryVersion changed to '1.6.0' as '1.6.1' cannot be found
    - net.cachapa.expandablelayout:expandablelayout:2.9.2' updated to new library name of 'com.github.cachapa:ExpandableLayout:2.9.2'

1. Updated the `build.gradle` to include new library locations.

1. Updated `ShowcaseBuilder.kt` to use new undocumented syntax of 'com.github.worker8:tourguide:1.0.18-SNAPSHOT'.

This PR will resolve Issue https://github.com/etesync/android/issues/272, Issue https://github.com/etesync/android/issues/273, and Issue https://github.com/etesync/android/issues/274.